### PR TITLE
Don't infer schema

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,16 @@ pub mod database {
 }
 
 pub mod schema {
-    infer_schema!("dotenv:DATABASE_URL");
+    table! {
+        campaigns (id) {
+            id -> Int8,
+            title -> Varchar,
+            description -> Nullable<Varchar>,
+            start_date -> Timestamp,
+            end_date -> Nullable<Timestamp>,
+            click_url -> Varchar,
+        }
+    }
 }
 
 pub mod api {


### PR DESCRIPTION
This makes it easier to deploy the project, as no database access is needed during build.